### PR TITLE
Quick fixes for usability

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     ],
     "activationEvents": [
         "onLanguage:abl",
-        "workspaceContains:openedge-project.json",
+        "workspaceContains:openedge-project.{json,jsonc}",
         "onTerminalProfile:proenv.terminal-profile"
     ],
     "main": "./dist/extension.js",
@@ -243,6 +243,7 @@
                             "name": "${2:Debug program / Interactive GUI}",
                             "type": "abl",
                             "request": "launch",
+                            "debugEnabled": true,
                             "program": "^\"${1:\\${file}}\"",
                             "cwd": "^\"\\${workspaceFolder}\"",
                             "graphicalMode": true
@@ -255,6 +256,20 @@
                             "name": "${2:Debug program / Interactive TTY}",
                             "type": "abl",
                             "request": "launch",
+                            "debugEnabled": true,
+                            "program": "^\"${1:\\${file}}\"",
+                            "cwd": "^\"\\${workspaceFolder}\"",
+                            "graphicalMode": false
+                        }
+                    },
+                    {
+                        "label": "ABL: Run program / Interactive TTY",
+                        "description": "Run the current file in interactive TTY mode",
+                        "body": {
+                            "name": "${2:Run program / Interactive TTY}",
+                            "type": "abl",
+                            "request": "launch",
+                            "debugEnabled": false,
                             "program": "^\"${1:\\${file}}\"",
                             "cwd": "^\"\\${workspaceFolder}\"",
                             "graphicalMode": false
@@ -306,9 +321,9 @@
                                 "description": "Attach to AVM or PASOE"
                             },
                             "port": {
-                                "type": "string",
+                                "type": "integer",
                                 "description": "The port that the debugger is listening on",
-                                "default": "3099"
+                                "default": 3099
                             },
                             "hostname": {
                                 "type": "string",
@@ -497,7 +512,7 @@
         },
         "jsonValidation": [
             {
-                "fileMatch": "openedge-project.json",
+                "fileMatch": "openedge-project.{json,jsonc}",
                 "url": "./resources/openedge.schema.json"
             }
         ],

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     ],
     "activationEvents": [
         "onLanguage:abl",
-        "workspaceContains:openedge-project.{json,jsonc}",
+        "workspaceContains:openedge-project.json",
         "onTerminalProfile:proenv.terminal-profile"
     ],
     "main": "./dist/extension.js",
@@ -497,7 +497,7 @@
         },
         "jsonValidation": [
             {
-                "fileMatch": "openedge-project.{json,jsonc}",
+                "fileMatch": "openedge-project.json",
                 "url": "./resources/openedge.schema.json"
             }
         ],

--- a/package.json
+++ b/package.json
@@ -243,7 +243,6 @@
                             "name": "${2:Debug program / Interactive GUI}",
                             "type": "abl",
                             "request": "launch",
-                            "debugEnabled": true,
                             "program": "^\"${1:\\${file}}\"",
                             "cwd": "^\"\\${workspaceFolder}\"",
                             "graphicalMode": true
@@ -256,20 +255,6 @@
                             "name": "${2:Debug program / Interactive TTY}",
                             "type": "abl",
                             "request": "launch",
-                            "debugEnabled": true,
-                            "program": "^\"${1:\\${file}}\"",
-                            "cwd": "^\"\\${workspaceFolder}\"",
-                            "graphicalMode": false
-                        }
-                    },
-                    {
-                        "label": "ABL: Run program / Interactive TTY",
-                        "description": "Run the current file in interactive TTY mode",
-                        "body": {
-                            "name": "${2:Run program / Interactive TTY}",
-                            "type": "abl",
-                            "request": "launch",
-                            "debugEnabled": false,
                             "program": "^\"${1:\\${file}}\"",
                             "cwd": "^\"\\${workspaceFolder}\"",
                             "graphicalMode": false

--- a/resources/abl-src/dynrun.p
+++ b/resources/abl-src/dynrun.p
@@ -43,8 +43,8 @@ LOG-MANAGER:WRITE-MESSAGE(SUBSTITUTE("JSON Config file: &1", SESSION:PARAMETER))
 OS-DELETE VALUE(SESSION:PARAMETER).
 
 //DB connections + aliases
-if configJson:has("databases") then
-do:
+IF configJson:has("databases") THEN
+DO:
   ASSIGN dbEntries = configJson:GetJsonArray("databases").
   DO zz = 1 TO dbEntries:Length:
     ASSIGN dbEntry = dbEntries:GetJsonObject(zz).

--- a/resources/abl-src/dynrun.p
+++ b/resources/abl-src/dynrun.p
@@ -42,28 +42,41 @@ ASSIGN configJson = CAST(jsonParser:ParseFile(SESSION:PARAMETER), JsonObject).
 LOG-MANAGER:WRITE-MESSAGE(SUBSTITUTE("JSON Config file: &1", SESSION:PARAMETER)).
 OS-DELETE VALUE(SESSION:PARAMETER).
 
-// DB connections + aliases
-ASSIGN dbEntries = configJson:GetJsonArray("databases").
-DO zz = 1 TO dbEntries:Length:
-  ASSIGN dbEntry = dbEntries:GetJsonObject(zz).
-  IF (dbEntry:has("name") AND dbEntry:has("connect")) THEN DO:
-    LOG-MANAGER:WRITE-MESSAGE(SUBSTITUTE("Connecting to DB '&1': '&2'", dbEntry:GetCharacter("name"), dbEntry:GetCharacter("connect"))).
-    CONNECT VALUE(dbEntry:GetCharacter("connect")) NO-ERROR.
-    IF ERROR-STATUS:ERROR THEN DO:
-      IF (ERROR-STATUS:NUM-MESSAGES > 1) OR (ERROR-STATUS:GET-NUMBER(1) NE 1552) THEN DO:
-        LOG-MANAGER:WRITE-MESSAGE(SUBSTITUTE("Unable to connect to '&1'" , dbEntry:GetCharacter("name"))).
-        DO i = 1 TO ERROR-STATUS:NUM-MESSAGES:
-          LOG-MANAGER:WRITE-MESSAGE(ERROR-STATUS:GET-MESSAGE(i)).
+//DB connections + aliases
+DO ON ERROR UNDO, LEAVE:
+  ASSIGN dbEntries = configJson:GetJsonArray("databases").
+  DO zz = 1 TO dbEntries:Length:
+    ASSIGN dbEntry = dbEntries:GetJsonObject(zz).
+    IF (dbEntry:has("name") AND dbEntry:has("connect")) THEN DO:
+      LOG-MANAGER:WRITE-MESSAGE(SUBSTITUTE("Connecting to DB '&1': '&2'", dbEntry:GetCharacter("name"), dbEntry:GetCharacter("connect"))).
+      CONNECT VALUE(dbEntry:GetCharacter("connect")) NO-ERROR.
+      IF ERROR-STATUS:ERROR THEN DO:
+        IF (ERROR-STATUS:NUM-MESSAGES > 1) OR (ERROR-STATUS:GET-NUMBER(1) NE 1552) THEN DO:
+          LOG-MANAGER:WRITE-MESSAGE(SUBSTITUTE("Unable to connect to '&1'" , dbEntry:GetCharacter("name"))).
+          DO i = 1 TO ERROR-STATUS:NUM-MESSAGES:
+            LOG-MANAGER:WRITE-MESSAGE(ERROR-STATUS:GET-MESSAGE(i)).
+          END.
+          QUIT.
         END.
-        QUIT.
+      END.
+      IF (dbEntry:has("aliases")) THEN DO:
+        DO zz2 = 1 TO dbEntry:GetJsonArray("aliases"):Length:
+          LOG-MANAGER:WRITE-MESSAGE(SUBSTITUTE("Create alias '&1' for '&2'", dbEntry:GetJsonArray("aliases"):GetCharacter(zz2), dbEntry:GetCharacter("name"))).
+          CREATE ALIAS VALUE(dbEntry:GetJsonArray("aliases"):GetCharacter(zz2)) FOR DATABASE VALUE(dbEntry:GetCharacter("name")).
+        END.
       END.
     END.
-    IF (dbEntry:has("aliases")) THEN DO:
-      DO zz2 = 1 TO dbEntry:GetJsonArray("aliases"):Length:
-        LOG-MANAGER:WRITE-MESSAGE(SUBSTITUTE("Create alias '&1' for '&2'", dbEntry:GetJsonArray("aliases"):GetCharacter(zz2), dbEntry:GetCharacter("name"))).
-        CREATE ALIAS VALUE(dbEntry:GetJsonArray("aliases"):GetCharacter(zz2)) FOR DATABASE VALUE(dbEntry:GetCharacter("name")).
+  END.
+  CATCH err AS Progress.Lang.Error:
+    IF err:GetMessageNum(1) = 16058 THEN DO: // "Call to Progress.Json.ObjectModel.JsonObject:GetJsonArray( ) failed. Property 'databases' was not found. (16058)"
+      // no DB connections configured in openedge-project.json
+      LOG-MANAGER:WRITE-MESSAGE(SUBSTITUTE("No DB connections detected in '" + SESSION:PARAMETER + "', running without any connections")).
+      DO i = 1 TO ERROR-STATUS:NUM-MESSAGES:
+        LOG-MANAGER:WRITE-MESSAGE(ERROR-STATUS:GET-MESSAGE(i)).
       END.
     END.
+    ELSE
+      UNDO, THROW err.
   END.
 END.
 

--- a/resources/abl-src/dynrun.p
+++ b/resources/abl-src/dynrun.p
@@ -43,7 +43,8 @@ LOG-MANAGER:WRITE-MESSAGE(SUBSTITUTE("JSON Config file: &1", SESSION:PARAMETER))
 OS-DELETE VALUE(SESSION:PARAMETER).
 
 //DB connections + aliases
-DO ON ERROR UNDO, LEAVE:
+if configJson:has("databases") then
+do:
   ASSIGN dbEntries = configJson:GetJsonArray("databases").
   DO zz = 1 TO dbEntries:Length:
     ASSIGN dbEntry = dbEntries:GetJsonObject(zz).
@@ -66,17 +67,6 @@ DO ON ERROR UNDO, LEAVE:
         END.
       END.
     END.
-  END.
-  CATCH err AS Progress.Lang.Error:
-    IF err:GetMessageNum(1) = 16058 THEN DO: // "Call to Progress.Json.ObjectModel.JsonObject:GetJsonArray( ) failed. Property 'databases' was not found. (16058)"
-      // no DB connections configured in openedge-project.json
-      LOG-MANAGER:WRITE-MESSAGE(SUBSTITUTE("No DB connections detected in '" + SESSION:PARAMETER + "', running without any connections")).
-      DO i = 1 TO ERROR-STATUS:NUM-MESSAGES:
-        LOG-MANAGER:WRITE-MESSAGE(ERROR-STATUS:GET-MESSAGE(i)).
-      END.
-    END.
-    ELSE
-      UNDO, THROW err.
   END.
 END.
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -532,7 +532,7 @@ function registerCommands(ctx: vscode.ExtensionContext) {
 
     readWorkspaceOEConfigFiles();
     // Monitor changes in all openedge-project.json files
-    vscode.workspace.createFileSystemWatcher('**/openedge-project.{json,jsonc}').onDidChange(uri => readOEConfigFile(uri));
+    vscode.workspace.createFileSystemWatcher('**/openedge-project.json').onDidChange(uri => readOEConfigFile(uri));
 }
 
 function readOEConfigFile(uri) {
@@ -558,7 +558,7 @@ function readOEConfigFile(uri) {
 }
 
 function readWorkspaceOEConfigFiles() {
-    vscode.workspace.findFiles('**/openedge-project.{json,jsonc}').then(list => {
+    vscode.workspace.findFiles('**/openedge-project.json').then(list => {
         list.forEach(uri => { readOEConfigFile(uri); });
     });
 }

--- a/src/shared/ablRun.ts
+++ b/src/shared/ablRun.ts
@@ -6,7 +6,20 @@ import { ProfileConfig, OpenEdgeProjectConfig } from './openEdgeConfigFile';
 import { tmpdir } from 'os';
 import { outputChannel } from '../ablStatus';
 
+const builderExists: { [rootDir: string]: boolean } = {};
+
+function checkBuilderDirectoryExists(rootDir: string) {
+    if (!builderExists[rootDir]) {
+        const builderDir = path.join(rootDir, ".builder");
+        if (!fs.existsSync(builderDir)) { //only check once.  restart the language server to check again
+            fs.mkdirSync(builderDir);
+        }
+        builderExists[rootDir] = true;
+    }
+}
+
 export function debug(filename: string, project: OpenEdgeProjectConfig, executable: string): cp.ChildProcessWithoutNullStreams {
+    checkBuilderDirectoryExists(project.rootDir);
     const env = process.env;
     env.DLC = project.dlc;
 
@@ -36,6 +49,7 @@ export function debug(filename: string, project: OpenEdgeProjectConfig, executab
 }
 
 export function runGUI(filename: string, project: OpenEdgeProjectConfig) {
+    checkBuilderDirectoryExists(project.rootDir);
     const env = process.env;
     env.DLC = project.dlc;
 
@@ -59,6 +73,7 @@ export function runGUI(filename: string, project: OpenEdgeProjectConfig) {
 }
 
 export function openInAB(filename: string, rootDir: string, project: ProfileConfig) {
+    checkBuilderDirectoryExists(rootDir);
     const env = process.env;
     env.DLC = project.dlc;
 

--- a/src/shared/ablRun.ts
+++ b/src/shared/ablRun.ts
@@ -23,6 +23,11 @@ export function debug(filename: string, project: OpenEdgeProjectConfig, executab
         debugger: true
     };
     fs.writeFileSync(prmFileName, JSON.stringify(cfgFile));
+    // create the .builder directory if it does not exist
+    const val = fs.statSync(path.join(project.rootDir, ".builder"));
+    if (!val.isDirectory() && !val.isFile()) {
+        fs.mkdirSync(path.join(project.rootDir, ".builder"));
+    }
     const prms = [ "-clientlog", path.join(project.rootDir, ".builder\\debugger.log"), "-p", path.join(__dirname, '../resources/abl-src/dynrun.p'), "-param", prmFileName , "-debugReady", "3099"];
     const prms2 = prms.concat(project.extraParameters.split(' '));
 


### PR DESCRIPTION
A handful few small fixes here that I think improve usability for those times when we're not working with a single project, or just want to run some quick code.

If for whatever reason you think we need to split up this PR just let me know... happy to do so.

# `openedge-project.json` .config

* Don't require that `"dbconnections": []` be defined in `openedge-project.json`
  * Fixes this runtime error:
    ![image](https://github.com/vscode-abl/vscode-abl/assets/3201462/6b2e5b0c-2cb0-42e2-a0b5-e5bbd3b5825b)
* See #107 ~~Allow for using `openedge-project.jsonc` instead of `openedge-project.json`.  Most of the other VSCode config files allow for comments, and it would be really helpful for this plugin too.~~
* When no source or propath entries are provided in `openedge-project.json` default the propath to `'.'`
* If no `"oeversion"` key is given, use the default from user settings if configured.

# `launch.json` config

* When creating a debug configuration the port field is set to "string" when it should really be an integer as it fails the schema validation.
    ![image](https://github.com/vscode-abl/vscode-abl/assets/3201462/268761bf-14ec-4759-acac-c3fde5c732b7)
    
# Terminal related fixes

* Create the `.builder/` directory on the first run of a task/command if needed to fix this error:
    ![image](https://github.com/vscode-abl/vscode-abl/assets/3201462/32a59351-536b-406d-9ee7-fc63844d0f50)
* When using the "**ABL: Run with _progres**" command change the dirsep character to `/` so it plays nicely with Git Bash.  Seems that using the forward slash is compatible with everything, but the back slash is not so friendly.  Tested with Git Bash, cmd, PowerShell.  No change needed on the other commands.
    ![image](https://github.com/vscode-abl/vscode-abl/assets/3201462/7402125d-0b50-4553-b277-5dfd0440391d)
