### PR TITLE
openedge-project.json - allow for comments via openedge-project.jsonc

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -25,6 +25,18 @@
             "preLaunchTask": "build"
         },
         {
+            "name": "Run Extension - Sample project 4 (jsonc)",
+            "type": "extensionHost",
+            "request": "launch",
+            "runtimeExecutable": "${execPath}",
+            "args": [
+                "--extensionDevelopmentPath=${workspaceFolder}", 
+                "${workspaceFolder}/run_env/sample-oe-projects/project4"
+            ],
+            "sourceMaps": true,
+            "preLaunchTask": "build"
+        },
+        {
             "name": "Run Extension - SonarTestProject",
             "type": "extensionHost",
             "request": "launch",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     ],
     "activationEvents": [
         "onLanguage:abl",
-        "workspaceContains:openedge-project.json",
+        "workspaceContains:openedge-project.{json,jsonc}",
         "onTerminalProfile:proenv.terminal-profile"
     ],
     "main": "./dist/extension.js",
@@ -497,7 +497,7 @@
         },
         "jsonValidation": [
             {
-                "fileMatch": "openedge-project.json",
+                "fileMatch": "openedge-project.{json,jsonc}",
                 "url": "./resources/openedge.schema.json"
             }
         ],

--- a/run_env/sample-oe-projects/project4/openedge-project.json
+++ b/run_env/sample-oe-projects/project4/openedge-project.json
@@ -1,0 +1,15 @@
+{
+  "version": "12.2",
+  "oeversion": "12.2",
+  //this is a comment!
+  "graphicalMode": true,
+  "extraParameters": "",
+  "buildPath": [
+    { "type": "source", "path": "src" }
+  ],
+  "buildDirectory": "build",
+  "dumpFiles": [],
+  "dbConnections": [],
+  "aliases": "",
+  "numThreads": 1
+}

--- a/run_env/sample-oe-projects/project4/src/test01.p
+++ b/run_env/sample-oe-projects/project4/src/test01.p
@@ -1,0 +1,3 @@
+message proversion.
+message "hello".
+message "hello2".

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -532,7 +532,7 @@ function registerCommands(ctx: vscode.ExtensionContext) {
 
     readWorkspaceOEConfigFiles();
     // Monitor changes in all openedge-project.json files
-    vscode.workspace.createFileSystemWatcher('**/openedge-project.json').onDidChange(uri => readOEConfigFile(uri));
+    vscode.workspace.createFileSystemWatcher('**/openedge-project.{json,jsonc}').onDidChange(uri => readOEConfigFile(uri));
 }
 
 function readOEConfigFile(uri) {
@@ -558,7 +558,7 @@ function readOEConfigFile(uri) {
 }
 
 function readWorkspaceOEConfigFiles() {
-    vscode.workspace.findFiles('**/openedge-project.json').then(list => {
+    vscode.workspace.findFiles('**/openedge-project.{json,jsonc}').then(list => {
         list.forEach(uri => { readOEConfigFile(uri); });
     });
 }


### PR DESCRIPTION
Breaking this off from #104 for further research/consideration.

## `openedge-project.json` .config

* Allow for using `openedge-project.jsonc` instead of `openedge-project.json`. Most of the other VSCode config files allow for comments, and it would be really helpful for this plugin too.