### PR TITLE
Quick fixes for usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,15 +22,14 @@ This extension requires:
 OpenEdge runtimes have to be declared in VSCode configuration file. Open settings `(Ctrl + comma)` -> Extensions -> ABL Configuration -> Runtimes, or modify `settings.json`:
 
 ```jsonc
+    "abl.configuration.runtimes.default": "12.2", // Default ABL version
     "abl.configuration.runtimes": [
         {
             "name": "12.2",
-            "default": true,
             "path": "C:/Progress/Openedge"
         },
         {
             "name": "11.7",
-            "default": false,
             "path": "C:\\Progress\\OpenEdge-11.7"
         }
     ],

--- a/package.json
+++ b/package.json
@@ -310,9 +310,9 @@
                                 "description": "Attach to AVM or PASOE"
                             },
                             "port": {
-                                "type": "string",
+                                "type": "integer",
                                 "description": "The port that the debugger is listening on",
-                                "default": "3099"
+                                "default": 3099
                             },
                             "hostname": {
                                 "type": "string",
@@ -445,6 +445,23 @@
                         "type": "string"
                     }
                 },
+                "abl.configuration.defaultRuntime": {
+                    "type": "string",
+                    "description": "Default OpenEdge Execution Environment name",
+                    "enum": [
+                        "9.1E",
+                        "10.2B",
+                        "11.5",
+                        "11.6",
+                        "11.7",
+                        "12.2",
+                        "12.4",
+                        "12.5",
+                        "12.6",
+                        "12.7",
+                        "ESAP"
+                    ]
+                },
                 "abl.configuration.runtimes": {
                     "type": "array",
                     "description": "Map OpenEdge Execution Environments to local installation",
@@ -480,7 +497,7 @@
                             },
                             "default": {
                                 "type": "boolean",
-                                "description": "Is default runtime? Only one runtime can be default."
+                                "description": "deprecated: use 'abl.configuration.runtimes.default'"
                             }
                         },
                         "additionalProperties": false


### PR DESCRIPTION
Opening in place of #104.

A handful few small fixes here that I think improve usability for those times when we're not working with a single project, or just want to run some quick code.

If for whatever reason you think we need to split up this PR just let me know... happy to do so.

## User settings

* add `abl.configuration.defaultRuntime`.  The previous `default` on the array will still work by taking the first one it finds.  This cleans up the config a bit by making it more clear that we should only have 1 default.
  * Could quite get `abl.configuration.runtimes.default` to work.  Didn't play nice with the array existing under the same naming convention.

## `openedge-project.json` .config

* Don't require that `"dbconnections": []` be defined in `openedge-project.json`
  * Fixes this runtime error:
    ![image](https://github.com/vscode-abl/vscode-abl/assets/3201462/6b2e5b0c-2cb0-42e2-a0b5-e5bbd3b5825b)
* When no source or propath entries are provided in `openedge-project.json` default the propath to `'.'`
* If no `"oeversion"` key is given, use the default from user settings if configured.

# `launch.json` config

* When creating a debug configuration the port field is set to "string" when it should really be an integer as it fails the schema validation.
    ![image](https://github.com/vscode-abl/vscode-abl/assets/3201462/268761bf-14ec-4759-acac-c3fde5c732b7)
    
# Terminal related fixes

* Create the `.builder/` directory on the first run of a task/command if needed to fix this error:
    ![image](https://github.com/vscode-abl/vscode-abl/assets/3201462/32a59351-536b-406d-9ee7-fc63844d0f50)
* When using the "**ABL: Run with _progres**" command change the dirsep character to `/` so it plays nicely with Git Bash.  Seems that using the forward slash is compatible with everything, but the back slash is not so friendly.  Tested with Git Bash, cmd, PowerShell.  No change needed on the other commands.
    ![image](https://github.com/vscode-abl/vscode-abl/assets/3201462/7402125d-0b50-4553-b277-5dfd0440391d)
