### PR TITLE
Enable Find Widget for OE Documentation Webview

### DIFF
--- a/src/OpenEdgeDocumentation.ts
+++ b/src/OpenEdgeDocumentation.ts
@@ -92,7 +92,7 @@ export class DocViewPanel {
     // Otherwise, create a new panel.
     const panel = vscode.window.createWebviewPanel('OEDOC', 'OpenEdge Documentation',
       column || vscode.ViewColumn.One,
-      { enableScripts: true }
+      { enableScripts: true, enableFindWidget: true }
     );
 
     DocViewPanel.currentPanel = new DocViewPanel(panel, page);


### PR DESCRIPTION
Adding `enableFindWidget` option to `WebviewPanelOptions` (https://code.visualstudio.com/api/references/vscode-api#WebviewPanelOptions) so that you can use <Ctrl+F> on Windows or the equivalent on Mac to search within the OpenEdge Documentation.