### PR TITLE
feat: stopLangServ command

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,6 +129,11 @@
         "description": "Open the Data Dictionary external tool"
       },
       {
+        "command": "abl.stop.langserv",
+        "title": "ABL: Stop Language Server",
+        "description": "Stop ABL Language Server"
+      },
+      {
         "command": "abl.restart.langserv",
         "title": "ABL: Restart Language Server",
         "description": "Restart ABL Language Server"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -172,6 +172,9 @@ export function activate(ctx: vscode.ExtensionContext) {
     async status() {
       return await client.sendRequest('proparse/status');
     },
+    async stopLanguageServer() {
+      return await stopLangServer();
+    },
     async restartLanguageServer() {
       return await restartLangServer();
     },
@@ -502,6 +505,12 @@ function setDefaultProject(): void {
 
 function dumpLangServStatus(): void {
   client.sendNotification('proparse/dumpStatus', {});
+}
+
+function stopLangServer(): Promise<void> {
+  outputChannel.info('Received request to restart ABL Language Server');
+  return client
+    .stop(5000);
 }
 
 function restartLangServer(): Promise<void> {
@@ -1382,6 +1391,7 @@ function registerCommands(ctx: vscode.ExtensionContext) {
       'abl.dumpLangServStatus',
       dumpLangServStatus,
     ),
+    vscode.commands.registerCommand('abl.stop.langserv', stopLangServer),
     vscode.commands.registerCommand('abl.restart.langserv', restartLangServer),
     vscode.commands.registerCommand('abl.compileBuffer', compileBuffer),
     vscode.commands.registerCommand('abl.debugListingLine', debugListingLine),


### PR DESCRIPTION
Hi,

As asked in [this issue](https://github.com/vscode-abl/vscode-abl/issues/526) we need to stop the langage server to update dependencies (.PL)

This PR allows us to shutdown the LS, do the copy and restart without having to close vscode

