### PR TITLE
New "Strip AppBuilder Markup" command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 dist/
+dist-test/
 npm*
 node_modules
 *.vsix

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "webpack-dev": "webpack --mode development --watch",
     "package": "webpack --mode production --devtool hidden-source-map",
     "lint": "eslint .",
+    "test": "tsc src/ablStripMarkupCore.ts src/test/ablStripMarkup.test.ts --outDir dist-test --target es2022 --module commonjs --skipLibCheck && node --test dist-test/test/ablStripMarkup.test.js",
     "grammar-version": "npm list abl-tmlanguage --depth=0 | head -2 | tail -1 | cut -c 5- > resources/grammar-version.txt"
   },
   "icon": "resources/images/progress_icon.png",
@@ -267,6 +268,11 @@
         "command": "abl.explorer.compile",
         "title": "Compile",
         "description": "Compile file or directory"
+      },
+      {
+        "command": "abl.stripMarkup",
+        "title": "ABL: Strip AppBuilder Markup",
+        "description": "Strip AppBuilder visual layout markup and metadata from OpenEdge files"
       }
     ],
     "breakpoints": [
@@ -690,6 +696,10 @@
         {
           "command": "abl.runProgres.currentFile",
           "when": "editorLangId == 'abl'"
+        },
+        {
+          "command": "abl.stripMarkup",
+          "when": "editorLangId == 'abl'"
         }
       ],
       "view/title": [
@@ -736,7 +746,12 @@
       "abl.explorerSubmenu": [
         {
           "command": "abl.explorer.compile",
-          "group": "01_compile@01",
+          "group": "01_file@01",
+          "when": "abl.isABLProject"
+        },
+        {
+          "command": "abl.stripMarkup",
+          "group": "01_file@02",
           "when": "abl.isABLProject"
         }
       ],
@@ -775,6 +790,11 @@
         {
           "command": "abl.generateXmlXref",
           "group": "01_file@06",
+          "when": "editorTextFocus && config.abl.showCommandsInContextMenu && resourceLangId == abl"
+        },
+        {
+          "command": "abl.stripMarkup",
+          "group": "01_file@07",
           "when": "editorTextFocus && config.abl.showCommandsInContextMenu && resourceLangId == abl"
         },
         {

--- a/package.json
+++ b/package.json
@@ -90,143 +90,171 @@
     "commands": [
       {
         "command": "abl.getDlcDirectory",
-        "title": "ABL: Return OE dir",
+        "category": "ABL",
+        "title": "Return OE dir",
         "enablement": "false",
         "description": "Return the OpenEdge installation directory for a project"
       },
       {
         "command": "abl.debugListingLine",
-        "title": "ABL: Find debug listing line",
+        "category": "ABL",
+        "title": "Find debug listing line",
         "description": "Find debug listing line"
       },
       {
         "command": "abl.openInAB",
-        "title": "ABL: Open file in AppBuilder",
+        "category": "ABL",
+        "title": "Open file in AppBuilder",
         "description": "Open current file in AppBuilder"
       },
       {
         "command": "abl.openInProcEd",
-        "title": "ABL: Open file in procedure editor",
+        "category": "ABL",
+        "title": "Open file in procedure editor",
         "description": "Open current file in procedure editor"
       },
       {
         "command": "abl.runProgres.currentFile",
-        "title": "ABL: Run with _progres",
+        "category": "ABL",
+        "title": "Run with _progres",
         "description": "Run current file in TTY session"
       },
       {
         "command": "abl.runBatch.currentFile",
-        "title": "ABL: Run with _progres -b",
+        "category": "ABL",
+        "title": "Run with _progres -b",
         "description": "Run current file in batch session"
       },
       {
         "command": "abl.runProwin.currentFile",
-        "title": "ABL: Run with prowin",
+        "category": "ABL",
+        "title": "Run with prowin",
         "description": "Run current file in GUI session"
       },
       {
         "command": "abl.dataDictionary",
-        "title": "ABL: Open Data Dictionary",
+        "category": "ABL",
+        "title": "Open Data Dictionary",
         "description": "Open the Data Dictionary external tool"
       },
       {
         "command": "abl.stop.langserv",
-        "title": "ABL: Stop Language Server",
+        "category": "ABL",
+        "title": "Stop Language Server",
         "description": "Stop ABL Language Server"
       },
       {
         "command": "abl.restart.langserv",
-        "title": "ABL: Restart Language Server",
+        "category": "ABL",
+        "title": "Restart Language Server",
         "description": "Restart ABL Language Server"
       },
       {
         "command": "abl.changeBuildMode",
-        "title": "ABL: Change build mode",
+        "category": "ABL",
+        "title": "Change build mode",
         "description": "Change ABL Build Mode"
       },
       {
         "command": "abl.project.rebuild",
-        "title": "ABL: Rebuild Project",
+        "category": "ABL",
+        "title": "Rebuild Project",
         "description": "Rebuild Project"
       },
       {
         "command": "abl.setDefaultProject",
-        "title": "ABL: Set default project",
+        "category": "ABL",
+        "title": "Set default project",
         "description": "Set default project"
       },
       {
         "command": "abl.project.switch.profile",
-        "title": "ABL: Switch project to profile",
+        "category": "ABL",
+        "title": "Switch project to profile",
         "description": "Switch project profile"
       },
       {
         "command": "abl.preprocess",
-        "title": "ABL: Preprocess current file",
+        "category": "ABL",
+        "title": "Preprocess current file",
         "description": "Preprocess current file"
       },
       {
         "command": "abl.dumpFileStatus",
-        "title": "ABL: Dump current file status",
+        "category": "ABL",
+        "title": "Dump current file status",
         "description": "Dump current file status"
       },
       {
         "command": "abl.compileBuffer",
-        "title": "ABL: Syntax check active editor",
+        "category": "ABL",
+        "title": "Syntax check active editor",
         "description": "Syntax check active editor"
       },
       {
         "command": "abl.generateListing",
-        "title": "ABL: Generate listing",
+        "category": "ABL",
+        "title": "Generate listing",
         "description": "Generate listing of current file"
       },
       {
         "command": "abl.generateDebugListing",
-        "title": "ABL: Generate debug listing",
+        "category": "ABL",
+        "title": "Generate debug listing",
         "description": "Generate debug listing of current file"
       },
       {
         "command": "abl.generateXref",
-        "title": "ABL: Generate XREF",
+        "category": "ABL",
+        "title": "Generate XREF",
         "description": "Generate XREF of current file"
       },
       {
         "command": "abl.generateXmlXref",
-        "title": "ABL: Generate XML-XREF",
+        "category": "ABL",
+        "title": "Generate XML-XREF",
         "description": "Generate XML-XREF of current file"
       },
       {
         "command": "abl.generateXrefAndJumpToCurrentLine",
-        "title": "ABL: Generate XREF and jump to current source line",
+        "category": "ABL",
+        "title": "Generate XREF and jump to current source line",
         "description": "Generate XREF of current file and jump to the current line in the XREF output"
       },
       {
         "command": "abl.catalog",
-        "title": "ABL: Generate Assembly Catalog",
+        "category": "ABL",
+        "title": "Generate Assembly Catalog",
         "description": "Generate Assembly Catalog"
       },
       {
         "command": "abl.fixUpperCasing",
-        "title": "ABL: Convert to uppercase",
+        "category": "ABL",
+        "title": "Convert to uppercase",
         "description": "Convert keywords to uppercase"
       },
       {
         "command": "abl.fixLowerCasing",
-        "title": "ABL: Convert to lowercase",
+        "category": "ABL",
+        "title": "Convert to lowercase",
         "description": "Convert keywords to lowercase"
       },
       {
         "command": "abl.expandKeywords",
-        "title": "ABL: Expand Keywords",
+        "category": "ABL",
+        "title": "Expand Keywords",
         "description": "Expand keywords"
       },
       {
         "command": "abl.organizeUsings",
-        "title": "ABL: Organize Usings",
+        "category": "ABL",
+        "title": "Organize Usings",
         "description": "Organize USING statements"
       },
       {
         "command": "abl.dumpLangServStatus",
-        "title": "ABL: Dump Language Server status",
+        "category": "ABL",
+        "title": "Dump Language Server status",
         "description": "Dump Language Server status"
       },
       {
@@ -266,12 +294,14 @@
       },
       {
         "command": "abl.explorer.compile",
+        "category": "ABL",
         "title": "Compile",
         "description": "Compile file or directory"
       },
       {
         "command": "abl.stripMarkup",
-        "title": "ABL: Strip AppBuilder Markup",
+        "category": "ABL",
+        "title": "Strip AppBuilder Markup",
         "description": "Strip AppBuilder visual layout markup and metadata from OpenEdge files"
       }
     ],

--- a/src/ablStripMarkup.ts
+++ b/src/ablStripMarkup.ts
@@ -1,0 +1,140 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as vscode from 'vscode';
+import { outputChannel } from './ablStatus';
+
+import { stripAppBuilderMarkup } from './ablStripMarkupCore';
+
+/**
+ * Handles in-place modifications of the open active text editor buffer.
+ */
+export async function stripMarkupActiveEditor() {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor) {
+    vscode.window.showWarningMessage('No active editor to strip markup from.');
+    return;
+  }
+
+  if (editor.document.languageId !== 'abl') {
+    vscode.window.showWarningMessage('Active file is not an OpenEdge ABL file.');
+    return;
+  }
+
+  const document = editor.document;
+  const rawText = document.getText();
+  const cleanedText = stripAppBuilderMarkup(rawText);
+
+  if (rawText === cleanedText) {
+    vscode.window.showInformationMessage('No AppBuilder markup found to strip.');
+    return;
+  }
+
+  const firstLine = document.lineAt(0);
+  const lastLine = document.lineAt(document.lineCount - 1);
+  const fullRange = new vscode.Range(firstLine.range.start, lastLine.range.end);
+
+  const success = await editor.edit((editBuilder) => {
+    editBuilder.replace(fullRange, cleanedText);
+  });
+
+  if (success) {
+    vscode.window.showInformationMessage('AppBuilder layout markup stripped successfully.');
+  } else {
+    vscode.window.showErrorMessage('Failed to apply edits to the active document.');
+  }
+}
+
+/**
+ * Handles batch processing of files and directories from the File Explorer Sidebar.
+ */
+export async function stripMarkupExplorer(uri: vscode.Uri, uris?: vscode.Uri[]) {
+  const targets = uris && uris.length > 0 ? uris : [uri];
+  if (targets.length === 0) {
+    return;
+  }
+
+  let filesToProcess: string[] = [];
+  for (const target of targets) {
+    if (target.scheme !== 'file') {
+      continue;
+    }
+    const fsPath = target.fsPath;
+    try {
+      const stat = fs.statSync(fsPath);
+      if (stat.isDirectory()) {
+        const dirFiles = await getAblFilesRecursively(fsPath);
+        filesToProcess = filesToProcess.concat(dirFiles);
+      } else {
+        const ext = path.extname(fsPath).toLowerCase();
+        if (['.w', '.p', '.i'].includes(ext)) {
+          filesToProcess.push(fsPath);
+        }
+      }
+    } catch (err: any) {
+      outputChannel.error(`Failed to inspect path ${fsPath}: ${err.message}`);
+    }
+  }
+
+  if (filesToProcess.length === 0) {
+    vscode.window.showWarningMessage('No OpenEdge ABL files found to process.');
+    return;
+  }
+
+  let successCount = 0;
+  let modifiedCount = 0;
+
+  await vscode.window.withProgress({
+    location: vscode.ProgressLocation.Notification,
+    title: 'Stripping AppBuilder Markup...',
+    cancellable: false
+  }, async (progress) => {
+    const total = filesToProcess.length;
+    for (let i = 0; i < total; i++) {
+      const filePath = filesToProcess[i];
+      progress.report({
+        message: `Processing file ${i + 1}/${total}: ${path.basename(filePath)}`,
+        increment: (1 / total) * 100
+      });
+      try {
+        const rawText = fs.readFileSync(filePath, 'utf8');
+        const cleanedText = stripAppBuilderMarkup(rawText);
+        if (rawText !== cleanedText) {
+          fs.writeFileSync(filePath, cleanedText, 'utf8');
+          modifiedCount++;
+        }
+        successCount++;
+      } catch (err: any) {
+        outputChannel.error(`Failed processing ${filePath}: ${err.message}`);
+      }
+    }
+  });
+
+  vscode.window.showInformationMessage(
+    `Stripping complete. Processed ${successCount} files. Modified ${modifiedCount} file(s).`
+  );
+}
+
+/**
+ * Recursively scans directories to retrieve all valid ABL extension files.
+ */
+async function getAblFilesRecursively(dirPath: string): Promise<string[]> {
+  let files: string[] = [];
+  try {
+    const list = fs.readdirSync(dirPath);
+    for (const item of list) {
+      const fullPath = path.join(dirPath, item);
+      const stat = fs.statSync(fullPath);
+      if (stat.isDirectory()) {
+        files = files.concat(await getAblFilesRecursively(fullPath));
+      } else {
+        const ext = path.extname(item).toLowerCase();
+        if (['.w', '.p', '.i'].includes(ext)) {
+          files.push(fullPath);
+        }
+      }
+    }
+  } catch (err: any) {
+    outputChannel.error(`Failed listing directory ${dirPath}: ${err.message}`);
+  }
+  return files;
+}

--- a/src/ablStripMarkupCore.ts
+++ b/src/ablStripMarkupCore.ts
@@ -1,0 +1,123 @@
+/**
+ * Strips AppBuilder-specific visual layout metadata and comment blocks.
+ * Does NOT alter general blank spacing or code structures.
+ */
+export function stripAppBuilderMarkup(sourceText: string): string {
+  if (!sourceText) {
+    return sourceText;
+  }
+
+  // 1. Detect line endings to preserve file format (CRLF vs LF)
+  const lineEnding = sourceText.includes('\r\n') ? '\r\n' : '\n';
+
+  // 2. Split into individual lines for fast single-line scanning
+  const lines = sourceText.split(/\r?\n/);
+  const outputLines: string[] = [];
+
+  // 3. Process single-line directives and headers
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    // Skip single-line preprocessor directives (e.g., &ANALYZE-SUSPEND)
+    if (trimmed.startsWith('&ANALYZE-')) {
+      continue;
+    }
+
+    // Skip single-line AppBuilder metadata comments (e.g., /* _UIB-CODE-BLOCK...)
+    if (trimmed.startsWith('/* _UIB-')) {
+      continue;
+    }
+
+    outputLines.push(line);
+  }
+
+  // 4. Recombine lines to process multi-line comments
+  let content = outputLines.join(lineEnding);
+
+  // 5. Strip multi-line /* Settings for THIS ... */ blocks
+  // Tracks nested comment depth to safely support nested OpenEdge comments
+  let scanIdx = 0;
+  while (true) {
+    const startIdx = content.indexOf('/* Settings for THIS', scanIdx);
+    if (startIdx === -1) {
+      break;
+    }
+
+    let depth = 1;
+    let currentSearchIdx = startIdx + 20; // Length of "/* Settings for THIS"
+    let trueEndIdx = -1;
+
+    while (depth > 0) {
+      const nextStart = content.indexOf('/*', currentSearchIdx);
+      const nextEnd = content.indexOf('*/', currentSearchIdx);
+
+      if (nextEnd === -1) {
+        break;
+      }
+
+      if (nextStart !== -1 && nextStart < nextEnd) {
+        depth++;
+        currentSearchIdx = nextStart + 2;
+      } else {
+        depth--;
+        trueEndIdx = nextEnd;
+        currentSearchIdx = nextEnd + 2;
+      }
+    }
+
+    if (trueEndIdx !== -1) {
+      content = content.substring(0, startIdx) + content.substring(trueEndIdx + 2);
+      scanIdx = startIdx; // Reset scan index since content length shortened
+    } else {
+      break;
+    }
+  }
+
+  // 6. Strip multi-line comments containing "(used by the UIB)"
+  // Tracks nested comment depth to safely support nested OpenEdge ABL comments and prevent syntax errors
+  scanIdx = 0;
+  while (true) {
+    const startIdx = content.indexOf('/*', scanIdx);
+    if (startIdx === -1) {
+      break;
+    }
+
+    let depth = 1;
+    let currentSearchIdx = startIdx + 2;
+    let trueEndIdx = -1;
+
+    while (depth > 0) {
+      const nextStart = content.indexOf('/*', currentSearchIdx);
+      const nextEnd = content.indexOf('*/', currentSearchIdx);
+
+      if (nextEnd === -1) {
+        break;
+      }
+
+      if (nextStart !== -1 && nextStart < nextEnd) {
+        depth++;
+        currentSearchIdx = nextStart + 2;
+      } else {
+        depth--;
+        trueEndIdx = nextEnd;
+        currentSearchIdx = nextEnd + 2;
+      }
+    }
+
+    if (trueEndIdx !== -1) {
+      const commentLength = trueEndIdx - startIdx + 2;
+      const commentBody = content.substring(startIdx, startIdx + commentLength);
+
+      if (commentBody.includes('(used by the UIB)')) {
+        content = content.substring(0, startIdx) + content.substring(trueEndIdx + 2);
+        scanIdx = startIdx; // Reset scan index since content length shortened
+      } else {
+        scanIdx = trueEndIdx + 2; // Keep this comment and skip past it
+      }
+    } else {
+      break;
+    }
+  }
+
+  return content;
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,6 +31,7 @@ import {
 } from './shared/openEdgeConfigFile';
 import { machineIdSync } from 'node-machine-id';
 import { usernameSync } from 'username';
+import { stripMarkupActiveEditor, stripMarkupExplorer } from './ablStripMarkup';
 
 let client: LanguageClient;
 
@@ -1472,6 +1473,16 @@ function registerCommands(ctx: vscode.ExtensionContext) {
     vscode.commands.registerCommand(
       'abl.explorer.compile',
       compileFromExplorer,
+    ),
+    vscode.commands.registerCommand(
+      'abl.stripMarkup',
+      (uri?: vscode.Uri, uris?: vscode.Uri[]) => {
+        if (uri) {
+          stripMarkupExplorer(uri, uris);
+        } else {
+          stripMarkupActiveEditor();
+        }
+      },
     ),
     vscode.commands.registerCommand(
       'ablOutline.goToSymbol',

--- a/src/test/ablStripMarkup.test.ts
+++ b/src/test/ablStripMarkup.test.ts
@@ -1,0 +1,79 @@
+import * as assert from 'node:assert';
+import { test } from 'node:test';
+import { stripAppBuilderMarkup } from '../ablStripMarkupCore';
+
+test('Preserves standard ABL code and normal comments', () => {
+  const code = `/* This is a normal comment */
+define variable i as integer no-undo.
+
+/* Normal multi-line comment
+   that does not contain any metadata */
+message i.
+`;
+  const result = stripAppBuilderMarkup(code);
+  assert.strictEqual(result, code);
+});
+
+test('Strips single-line &ANALYZE- preprocessor directives', () => {
+  const code = `&ANALYZE-SUSPEND _VERSION-NUMBER UIB_v9r12
+define variable c as character no-undo.
+&ANALYZE-RESUME
+`;
+  const expected = `define variable c as character no-undo.
+`;
+  const result = stripAppBuilderMarkup(code);
+  assert.strictEqual(result, expected);
+});
+
+test('Strips single-line /* _UIB- comments', () => {
+  const code = `/* _UIB-CODE-BLOCK _CUSTOM _DEFINITIONS */
+message "hello".
+`;
+  const expected = `message "hello".
+`;
+  const result = stripAppBuilderMarkup(code);
+  assert.strictEqual(result, expected);
+});
+
+test('Strips multi-line Settings for THIS blocks', () => {
+  const code = `/* Settings for THIS Procedure
+   Type: Procedure
+   Allow: 
+   Frames: 1
+*/
+message "world".
+`;
+  const expected = `
+message "world".
+`;
+  const result = stripAppBuilderMarkup(code);
+  assert.strictEqual(result, expected);
+});
+
+test('Strips multi-line comments containing "(used by the UIB)"', () => {
+  const code = `/* DESIGN Window definition (used by the UIB)
+   CREATE WINDOW Procedure ASSIGN
+          HEIGHT             = 34.67
+          WIDTH              = 61.2.
+   /* END WINDOW DEFINITION */
+*/
+define button b_ok.
+`;
+  const expected = `
+define button b_ok.
+`;
+  const result = stripAppBuilderMarkup(code);
+  assert.strictEqual(result, expected);
+});
+
+test('Preserves line endings (LF vs CRLF)', () => {
+  // LF
+  const lfCode = `&ANALYZE-SUSPEND\nmessage 1.\n`;
+  const lfExpected = `message 1.\n`;
+  assert.strictEqual(stripAppBuilderMarkup(lfCode), lfExpected);
+
+  // CRLF
+  const crlfCode = `&ANALYZE-SUSPEND\r\nmessage 1.\r\n`;
+  const crlfExpected = `message 1.\r\n`;
+  assert.strictEqual(stripAppBuilderMarkup(crlfCode), crlfExpected);
+});


### PR DESCRIPTION
Feature is available in:
- Editor context menu
- Explorer file/folder context menu
- Command palette

Includes unit tests.

Also applied small fix in separate commit: Change title of ABL commands to omit "ABL: " prefix and instead use "ABL" category. This still correctly prefixes the commands in the command palette (CTRL+SHIFT+P), but omits the prefix when shown under the "ABL" parent in the context menu, where it was superfluous.