### PR TITLE
Added category to the commands prefixed with hardcoded "ABL"

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,143 +131,171 @@
     "commands": [
       {
         "command": "abl.getDlcDirectory",
-        "title": "ABL: Return OE dir",
+        "title": "Return OE dir",
+        "category": "ABL",
         "enablement": "false",
         "description": "Return the OpenEdge installation directory for a project"
       },
       {
         "command": "abl.debugListingLine",
-        "title": "ABL: Find debug listing line",
+        "title": "Find debug listing line",
+        "category": "ABL",
         "description": "Find debug listing line"
       },
       {
         "command": "abl.openInAB",
-        "title": "ABL: Open file in AppBuilder",
+        "title": "Open file in AppBuilder",
+        "category": "ABL",
         "description": "Open current file in AppBuilder"
       },
       {
         "command": "abl.openInProcEd",
-        "title": "ABL: Open file in procedure editor",
+        "title": "Open file in procedure editor",
+        "category": "ABL",
         "description": "Open current file in procedure editor"
       },
       {
         "command": "abl.runProgres.currentFile",
-        "title": "ABL: Run with _progres",
+        "title": "Run with _progres",
+        "category": "ABL",
         "description": "Run current file in TTY session"
       },
       {
         "command": "abl.runBatch.currentFile",
-        "title": "ABL: Run with _progres -b",
+        "title": "Run with _progres -b",
+        "category": "ABL",
         "description": "Run current file in batch session"
       },
       {
         "command": "abl.runProwin.currentFile",
-        "title": "ABL: Run with prowin",
+        "title": "Run with prowin",
+        "category": "ABL",
         "description": "Run current file in GUI session"
       },
       {
         "command": "abl.dataDictionary",
-        "title": "ABL: Open Data Dictionary",
+        "title": "Open Data Dictionary",
+        "category": "ABL",
         "description": "Open the Data Dictionary external tool"
       },
       {
         "command": "abl.stop.langserv",
-        "title": "ABL: Stop Language Server",
+        "title": "Stop Language Server",
+        "category": "ABL",
         "description": "Stop ABL Language Server"
       },
       {
         "command": "abl.restart.langserv",
-        "title": "ABL: Restart Language Server",
+        "title": "Restart Language Server",
+        "category": "ABL",
         "description": "Restart ABL Language Server"
       },
       {
         "command": "abl.changeBuildMode",
-        "title": "ABL: Change build mode",
+        "title": "Change build mode",
+        "category": "ABL",
         "description": "Change ABL Build Mode"
       },
       {
         "command": "abl.project.rebuild",
-        "title": "ABL: Rebuild Project",
+        "title": "Rebuild Project",
+        "category": "ABL",
         "description": "Rebuild Project"
       },
       {
         "command": "abl.setDefaultProject",
-        "title": "ABL: Set default project",
+        "title": "Set default project",
+        "category": "ABL",
         "description": "Set default project"
       },
       {
         "command": "abl.project.switch.profile",
-        "title": "ABL: Switch project to profile",
+        "title": "Switch project to profile",
+        "category": "ABL",
         "description": "Switch project profile"
       },
       {
         "command": "abl.preprocess",
-        "title": "ABL: Preprocess current file",
+        "title": "Preprocess current file",
+        "category": "ABL",
         "description": "Preprocess current file"
       },
       {
         "command": "abl.dumpFileStatus",
-        "title": "ABL: Dump current file status",
+        "title": "Dump current file status",
+        "category": "ABL",
         "description": "Dump current file status"
       },
       {
         "command": "abl.compileBuffer",
-        "title": "ABL: Syntax check active editor",
+        "title": "Syntax check active editor",
+        "category": "ABL",
         "description": "Syntax check active editor"
       },
       {
         "command": "abl.generateListing",
-        "title": "ABL: Generate listing",
+        "title": "Generate listing",
+        "category": "ABL",
         "description": "Generate listing of current file"
       },
       {
         "command": "abl.generateDebugListing",
-        "title": "ABL: Generate debug listing",
+        "title": "Generate debug listing",
+        "category": "ABL",
         "description": "Generate debug listing of current file"
       },
       {
         "command": "abl.generateXref",
-        "title": "ABL: Generate XREF",
+        "title": "Generate XREF",
+        "category": "ABL",
         "description": "Generate XREF of current file"
       },
       {
         "command": "abl.generateXmlXref",
-        "title": "ABL: Generate XML-XREF",
+        "title": "Generate XML-XREF",
+        "category": "ABL",
         "description": "Generate XML-XREF of current file"
       },
       {
         "command": "abl.generateXrefAndJumpToCurrentLine",
-        "title": "ABL: Generate XREF and jump to current source line",
+        "title": "Generate XREF and jump to current source line",
+        "category": "ABL",
         "description": "Generate XREF of current file and jump to the current line in the XREF output"
       },
       {
         "command": "abl.catalog",
-        "title": "ABL: Generate Assembly Catalog",
+        "title": "Generate Assembly Catalog",
+        "category": "ABL",
         "description": "Generate Assembly Catalog"
       },
       {
         "command": "abl.fixUpperCasing",
-        "title": "ABL: Convert to uppercase",
+        "title": "Convert to uppercase",
+        "category": "ABL",
         "description": "Convert keywords to uppercase"
       },
       {
         "command": "abl.fixLowerCasing",
-        "title": "ABL: Convert to lowercase",
+        "title": "Convert to lowercase",
+        "category": "ABL",
         "description": "Convert keywords to lowercase"
       },
       {
         "command": "abl.expandKeywords",
-        "title": "ABL: Expand Keywords",
+        "title": "Expand Keywords",
+        "category": "ABL",
         "description": "Expand keywords"
       },
       {
         "command": "abl.organizeUsings",
-        "title": "ABL: Organize Usings",
+        "title": "Organize Usings",
+        "category": "ABL",
         "description": "Organize USING statements"
       },
       {
         "command": "abl.dumpLangServStatus",
-        "title": "ABL: Dump Language Server status",
+        "title": "Dump Language Server status",
+        "category": "ABL",
         "description": "Dump Language Server status"
       },
       {


### PR DESCRIPTION
Hi team,

I have added category: ABL to all the commands that had hardcoded "ABL:" in their title and removed the hardcoded ABL: from the titles.

This is done to cleanup command titles as the category automatically applies the prefix. This also helps with the submenu cleaning as the commands are not prefixed with ABL: anymore in the submenu.

Thanks,
Ashish

P.S: Created a previous PR on the main branch by mistake. Closed that one and opened this. 